### PR TITLE
iperf_vsock: Unlink UNIX domain socket path only in server mode

### DIFF
--- a/src/iperf_vsock.c
+++ b/src/iperf_vsock.c
@@ -141,7 +141,8 @@ vsock_sockaddr(const char *cid_str, int port, int listen, socklen_t *len)
 	}
 
 	/* AF_UNIX path is not removed on socket close */
-	(void)unlink(sun->sun_path);
+	if (listen)
+		(void)unlink(sun->sun_path);
 
 	return (struct sockaddr *)sun;
 }


### PR DESCRIPTION
Delete the UNIX domain socket only when the socket is used for
listening, not for connecting.

This is needed to not get the following error when iperf is running in
server mode:

"iperf3: error - unable to start listener for connections: Address
already in use"

Signed-off-by: Andra Paraschiv <andraprs@amazon.com>

_PLEASE NOTE the following text from the iperf3 license.  Submitting a
pull request to the iperf3 repository constitutes "[making]
Enhancements available...publicly":_

```
You are under no obligation whatsoever to provide any bug fixes, patches, or
upgrades to the features, functionality or performance of the source code
("Enhancements") to anyone; however, if you choose to make your Enhancements
available either publicly, or directly to Lawrence Berkeley National
Laboratory, without imposing a separate written license agreement for such
Enhancements, then you hereby grant the following license: a non-exclusive,
royalty-free perpetual license to install, use, modify, prepare derivative
works, incorporate into other computer software, distribute, and sublicense
such enhancements or derivative works thereof, in binary and source code form.
```

_The complete iperf3 license is available in the `LICENSE` file in the
top directory of the iperf3 source tree._

* Version of iperf3 (or development branch, such as `master` or
  `3.1-STABLE`) to which this pull request applies:

* Issues fixed (if any):

* Brief description of code changes (suitable for use as a commit message):

