### PR TITLE
vsock: Add support for connecting to sibling VMs

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,16 @@ Connecting to host 3, port 5201
 iperf Done.
 ```
 
+### Sibling VMs
+
+`iperf` between sibling VMs is also possible. In this case, you must use
+the CID of the sibling VM prefixed with `s` (e.g. `s4`) in the `iperf`
+client command. Example:
+
+```shell
+iperf3 --vsock -c s4
+```
+
 ## Firecracker's hybrid VSOCK over AF_UNIX
 
 Firecracker, Cloud Hypervisor, and QEMU's vhost-user-vsock implement the


### PR DESCRIPTION
Allow connection to a sibling VM by setting the `VMADDR_FLAG_TO_HOST` flag in `sockaddr_vm`. Sibling VMs are specified in the client command by specifying the host for the `--client (-c)` CLI argument as the sibling VM CID prefixed with `s` (e.g. `s4`).