### PR TITLE
chore: Ignore build directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@ examples/.libs
 examples/Makefile
 examples/mic
 examples/mis
+build


### PR DESCRIPTION
The "build" directory is used to store building files and artifacts that
should be ignored by git.